### PR TITLE
[proposal] auto named routes for controllers

### DIFF
--- a/src/JasonLewis/EnhancedRouter/Router.php
+++ b/src/JasonLewis/EnhancedRouter/Router.php
@@ -267,7 +267,7 @@ class Router extends IlluminateRouter {
 		$nameControllerPart = lcfirst(preg_replace('/Controller.*/', '', $controller, 1));
 		$nameMethodPart = lcfirst(preg_replace('/(get|post|put|patch|delete)/', '', $method, 1));
 		
-		$name = $name ?: $nameControllerPart.'.'.$nameMethodPart;
+		$name = !$name and $nameMethodPart? $nameControllerPart.'.'.$nameMethodPart : $name;
 
 		return array('as' => $name, 'uses' => $controller.'@'.$method);
 	}


### PR DESCRIPTION
So resourceful routes have automatic named routes, but restful controllers does not.

Basically now Route::controller('/', 'HomeController') would give you the following named routes:
- home.index
- home.contact

(given that your controller had getIndex and getContact)
